### PR TITLE
Fixed `const_missing': uninitialized constant RDoc::Store (NameError)

### DIFF
--- a/lib/rspec_kickstarter/generator.rb
+++ b/lib/rspec_kickstarter/generator.rb
@@ -113,8 +113,8 @@ class RSpecKickstarter::Generator
     end
 
     # RDoc::Stats initialization
-    if RUBY_VERSION.to_f >= 2.0
-      # Ruby 2.0 requires RDoc::Store internally.
+    if defined?(RDoc::Store)
+      # RDoc 4.0.0 requires RDoc::Store internally.
       store = RDoc::Store.new
       top_level.store = store
       stats = RDoc::Stats.new(store, 1)


### PR DESCRIPTION
Added rspec-kickstarter to Rails 4.0.0 projects Gemfile.
Execute the following command, and get the const_missing error.

```
$ bundle exec rspec-kickstarter -r app
/xxx/vendor/bundle/ruby/2.0.0/gems/rdoc-3.12.2/lib/rdoc.rb:105:in `const_missing': uninitialized constant RDoc::Store (NameError)
    from /xxx/vendor/bundle/ruby/2.0.0/gems/rspec-kickstarter-0.2.4/lib/rspec_kickstarter/generator.rb:118:in `get_ruby_parser'
```

My environments are 
- ruby 2.0.0
- RDoc 3.12.2
  - sdoc depends on RDoc version 3.x
